### PR TITLE
Testing runs

### DIFF
--- a/benchtools/benchmark.py
+++ b/benchtools/benchmark.py
@@ -123,7 +123,7 @@ class Bench():
             for task_dir in task_list:
                 # load the tasks
                 task_path = os.path.join(task_folder, task_dir)
-                task = Task.from_txt_csv(task_path)
+                task = Task.from_txt_csv(task_path, source_path=bench_path)
                 tasks.append(task)
         else:
             tasks = []

--- a/benchtools/runner.py
+++ b/benchtools/runner.py
@@ -27,7 +27,8 @@ class BenchRunner():
         self.model = model
         api_default = {'ollama_api': "http://localhost:11434",
                            'openai':"https://api.openai.com/v1",
-                           'ollama':""}
+                           'ollama':"",
+                           'bedrock':""}
         if api:
             self.api = api 
         else:

--- a/benchtools/task.py
+++ b/benchtools/task.py
@@ -170,10 +170,18 @@ class Task:
         with open(os.path.join(task_path, "template.txt"), "r") as f:
             prompt = f.read()
 
+        info_file = os.path.join(task_path,'info.yml')
+        if os.path.exists(info_file):
+            with open(info_file, "r") as f:
+                info_dict = yaml.safe_load(f)
+        else:
+            info_dict= {}
+
         values_file = os.path.join(task_path, "values.csv")
         # load and strip whitespace from column names and values
         value_answer_df = pd.read_csv(values_file).rename(columns=lambda x: x.strip()).applymap(lambda x: x.strip() if isinstance(x, str) else x)
         
+        # TODO: Check info_dict for calculated?
         if 'reference' in value_answer_df.columns:
             variant_values = value_answer_df.drop(columns='reference').to_dict(orient='records')
         
@@ -193,14 +201,6 @@ class Task:
         else:
             description = f"a template based task with template: {prompt} and values like:\n\n {value_answer_df.head().to_markdown()}"
 
-        info_file = os.path.join(task_path,'task.yml')
-        if os.path.exists(info_file):
-            with open(info_file, "r") as f:
-                info_dict = yaml.safe_load(f) 
-        else:
-            info_dict= {}
-
-        
         return cls(task_name, template= prompt,
                     variant_values = variant_values, 
                     description = description,

--- a/demos/folderbench/multiple_models.yml
+++ b/demos/folderbench/multiple_models.yml
@@ -1,4 +1,4 @@
-runner_type: ollama
+runner_type: bedrock
 model: 
- - 'llama3.2'
- - 'gemma3'
+ - 'meta.llama3-70b-instruct-v1:0'
+ - 'google.gemma-3-4b-it '


### PR DESCRIPTION
- Runner: Working towards making sure he runner module is compatible with bedrock
  - [ ] How is runner.yml or multiple_models.yml being used?
- Task: from_txt_csv() looks for task.yml while demo has info.yml. How should we address this inconsistency?
- [x] Benchmark: from_txt_csv() requires a source path and from_folders doesn't provide one. 
- [ ] Task: prompt_id_generator() is being called twice, once in generate_prompts() and once in label_references(). Should we fix it so it's called once?